### PR TITLE
soong: Allow LLVM Binutils and LLD to be used

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -111,6 +111,12 @@ var Configuration = map[string]PathConfig{
         "arm-linux-androidkernel-ld": Allowed,
 	"aarch64-linux-gnu-as": Allowed,
         "aarch64-linux-gnu-ld": Allowed,
+	"llvm-ar":   Allowed,
+	"llvm-nm":   Allowed,
+	"llvm-objcopy":   Allowed,
+	"llvm-objdump":   Allowed,
+	"llvm-strip":   Allowed,
+	"aarch64-elf-ld.lld":   Allowed,
 	// Host toolchain is removed. In-tree toolchain should be used instead.
 	// GCC also can't find cc1 with this implementation.
 	"ar":         Forbidden,


### PR DESCRIPTION
* needed as we use RELR which requires usage of llvm binutils and lld

Signed-off-by: Cyber Knight <cyberknight755@gmail.com>