### PR TITLE
Add exported-to-kati namespaces to root namespace

### DIFF
--- a/android/namespace.go
+++ b/android/namespace.go
@@ -132,6 +132,9 @@ func (r *NameResolver) addNamespace(namespace *Namespace) (err error) {
 			return fmt.Errorf("a namespace must be the first module in the file")
 		}
 	}
+	if (namespace.exportToKati) {
+		r.rootNamespace.visibleNamespaces = append(r.rootNamespace.visibleNamespaces, namespace)
+	}
 	r.sortedNamespaces.add(namespace)
 
 	r.namespacesByDir.Store(namespace.Path, namespace)


### PR DESCRIPTION
This lets us use boot jar modules that are hidden behind
soong_namespace.

https://review.lineageos.org/c/LineageOS/android_build_soong/+/322217

Change-Id: If0068387efdeca5458b5b97ce6b993b10a268bd2

